### PR TITLE
Make Nim code simpler and faster

### DIFF
--- a/nim/benchmark.nim
+++ b/nim/benchmark.nim
@@ -12,10 +12,10 @@ let
   content = parseFile(filename)
 var points = newSeq[Point]()
 for p in content.items:
-  points.add(Point(x: p[0].fnum, y: p[1].fnum))
-let start = epochTime()
+  points.add((x: p[0].fnum, y: p[1].fnum))
+let start = cpuTime()
 for i in 0 .. (iterations-1):
   discard run(points, n)
-let time = ((epochTime() - start) * 1000 / float(iterations)).round
+let time = ((cpuTime() - start) * 1000 / float(iterations)).round
 
 echo "Made $1 iterations with an average of $2 milliseconds".format(iterations, time)


### PR DESCRIPTION
Not sure if you want pull requests, but I can't resist to improve benchmarks. All I had to do was make the code cleaner and fix a bug in `groupby`. You used this:

``` nim
var s = g[c]
s.add(p)
```

This copies `g[c]` into a new variable s, instead of modifying `g[c]` directly. That's probably not what you want! You can modify it directly like this:

``` nim
g.mget(c).add(p)
```

Running time went down from 547 ms to 324 ms for me.
