### PR TITLE
Fix quadratic dict:append/3 behaviour and use more idiomatic Erlang.

### DIFF
--- a/erlang/kmeans.erl
+++ b/erlang/kmeans.erl
@@ -52,13 +52,9 @@ clusters(Xs, Centroids) ->
 	groupBy(Xs, fun(X) -> closest(X, Centroids) end).
 
 groupBy(L, Fn) ->
-	TableId = groupBy(L, Fn, dict:new()),
-	values(dict:to_list(TableId)).
-
-values([]) -> [];
-values([{_, V} | T]) ->
-	[V | values(T)].
-
-groupBy([], _, TId) -> TId;
-groupBy([H | T], Fn, TId) ->
-	groupBy(T, Fn, dict:append(erlang:phash2(Fn(H)), H, TId)).
+    Group = fun(X, Dict) ->
+                    Add = fun(T) -> [X|T] end,
+                    dict:update(Fn(X), Add, [X], Dict)
+            end,
+    Dict = lists:foldl(Group, dict:new(), L),
+    [ V || {_,V} <- dict:to_list(Dict)].

--- a/erlang/kmeans.erl
+++ b/erlang/kmeans.erl
@@ -1,55 +1,44 @@
 -module(kmeans).
 -export([run/3]).
+-compile(inline).
 
 run(Xs, N, Iters) ->
-	InitCentroids = lists:sublist(Xs, N),
-	step(Iters, Xs, InitCentroids).
-
-step(N, Xs, Centroids) ->
-	NewCentroids = lists:map(fun(X) -> average(X) end, clusters(Xs, Centroids)),
-	case N of
-		0 -> NewCentroids;
-		_ -> step((N-1), Xs, NewCentroids)
-	end.
+    InitCentroids = lists:sublist(Xs, N),
+    Step = fun(_, Centroids) ->
+                   [average(X) || X <- clusters(Xs, Centroids)]
+           end,
+    lists:foldl(Step, InitCentroids, lists:seq(1, Iters)).
 
 divide({Px,Py}, K) ->
-	{Px/K, Py/K}.
+    {Px/K, Py/K}.
 
 add({Px1, Py1}, {Px2, Py2}) ->
-	{(Px1+Px2), (Py1+Py2)}.
+    {(Px1+Px2), (Py1+Py2)}.
 
 sub({Px1, Py1}, {Px2, Py2}) ->
-	{(Px1-Px2), (Py1-Py2)}.
+    {(Px1-Px2), (Py1-Py2)}.
 
-sq(X) -> 
-	X*X.
+sq(X) ->
+    X*X.
 
 modulus({Px, Py}) ->
-	math:sqrt((sq(Px) + sq(Py))).
+    math:sqrt((sq(Px) + sq(Py))).
 
 dist(P1, P2) ->
-	modulus(sub(P1,P2)).
+    modulus(sub(P1,P2)).
 
-average([]) -> 0;
-average(Q) -> divide(sum(Q),length(Q)).
+average(Q) ->
+    divide(sum(Q),length(Q)).
 
-sum([]) -> 0;
-sum([H]) -> H;
-sum([H | T]) -> add(H,sum(T)).
+sum(L) ->
+    Add = fun(X, Acc) -> add(X, Acc) end,
+    lists:foldl(Add, {0.0, 0.0}, L).
 
-closest(P, [H | T]) ->
-	First = {dist(P, H), H},
-	closest(P, T, First).
-closest(_, [], {_, Found}) -> Found;
-closest(P, [H | T], {ActualWeight, ActualPoint}) ->
-	NewWeight = dist(H, P),
-	if
-		NewWeight > ActualWeight -> closest(P, T, {ActualWeight, ActualPoint});
-		true -> closest(P, T, {NewWeight, H})
-	end.
-	
+closest(P, Centroids) ->
+    element(2, lists:min([{dist(P, C), C} || C <- Centroids])).
+
 clusters(Xs, Centroids) ->
-	groupBy(Xs, fun(X) -> closest(X, Centroids) end).
+    groupBy(Xs, fun(X) -> closest(X, Centroids) end).
 
 groupBy(L, Fn) ->
     Group = fun(X, Dict) ->

--- a/erlang/main.erl
+++ b/erlang/main.erl
@@ -7,27 +7,21 @@ n() -> 10.
 iters() -> 15.
 
 run() ->
-	{ok, Device} = file:open("../points.json", [read]),
-	Line = io:get_line(Device, noLine),
-	Tokens = string:tokens(Line, ",[]"),
-	Xs = getFloats(Tokens),
-	Times = lists:seq(1, times()),
-	Sums = [getTime(Xs) || _ <- Times],
-	Time = lists:sum(Sums)/length(Times),
+	Xs = read_points("../points.json"),
+	Times = [getTime(Xs) || _ <- lists:seq(1, times())],
+	Time = lists:sum(Times)/times(),
 	Time.
 
+read_points(FileName) ->
+    {ok, Data} = file:read_file(FileName),
+    [<<>>|Bins] = re:split(Data, "[][,]+", [trim]),
+    points([binary_to_float(X) || X <- Bins]).
+
 getTime(Xs) ->
-	TimeBefore = get_timestamp(),
-	kmeans:run(Xs, n(), iters()),
-	TimeAfter = get_timestamp(),
-	TimeAfter - TimeBefore.
+    Ms = element(1, timer:tc(kmeans, run, [Xs, n(), iters()]))/1000,
+%    io:write(Ms), io:nl(),
+    Ms.
 
-getFloats([]) -> [];
-getFloats([H1, H2 | T]) ->
-	[F1 | _ ] = tuple_to_list(string:to_float(H1)),
-	[F2 | _ ] = tuple_to_list(string:to_float(H2)),
-	[{F1, F2} | getFloats(T)].
-
-get_timestamp() ->
-	{Mega, Sec, Micro} = os:timestamp(),
-	(Mega*1000000 + Sec)*1000 + round(Micro/1000). 
+points([]) -> [];
+points([H1, H2 | T]) ->
+	[{H1, H2} | points(T)].


### PR DESCRIPTION
`dict:append/3` appends value at the end of the list which has quadratic behaviour. As stated in documentation:

> For example append/3 could be defined as:

```
append(Key, Val, D) ->
    update(Key, fun (Old) -> Old ++ [Val] end, [Val], D).
```

The solution is to prepend value in front of list using `dict:update/4`.

This version is about 24 times faster than using `dict:append/3` for given data on mine computer.
