### PR TITLE
Rust refactoring: rustc_serialize deprecated in favour of serde

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,15 +1,21 @@
 [package]
 
 name = "kmeans"
-version = "0.1.1"
+version = "0.1.2"
 authors = [ "Andrea Ferretti <ferrettiandrea@gmail.com>" ]
 
 
-[[bin]]
-
+[lib]
 name = "kmeans"
+path = "src/lib.rs"
+
+[[bin]]
+name = "kmeans_bin"
+path = "src/main.rs"
 
 [dependencies]
-rustc-serialize = "0.3"
+serde = "1.0.8"
+serde_derive = "1.0.8"
+serde_json = "1.0.2"
 
 time = "*"

--- a/rust/src/algo.rs
+++ b/rust/src/algo.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
-use std::collections::hash_map::Entry::{Occupied,Vacant};
+use std::collections::hash_map::Entry::{Occupied, Vacant};
 
 use point::Point;
 
-fn dist(v: Point, w: Point) -> f64 { (v - w).norm() }
+fn dist(v: Point, w: Point) -> f64 {
+    (v - w).norm()
+}
 
 fn avg(points: &[Point]) -> Point {
     let Point(x, y) = points.iter().fold(Point(0.0, 0.0), |p, &q| p + q);
@@ -15,10 +17,11 @@ fn avg(points: &[Point]) -> Point {
 fn closest(x: Point, ys: &[Point]) -> Point {
     let y0 = ys[0];
     let d0 = dist(y0, x);
-    let (_, y) = ys.iter().fold((d0, y0), |(m, p), &q| {
-        let d = dist(q, x);
-        if d < m { (d, q) } else { (m, p) }
-    });
+    let (_, y) = ys.iter()
+        .fold((d0, y0), |(m, p), &q| {
+            let d = dist(q, x);
+            if d < m { (d, q) } else { (m, p) }
+        });
     y
 }
 
@@ -31,18 +34,27 @@ fn clusters(xs: &[Point], centroids: &[Point]) -> Vec<Vec<Point>> {
         // Notable change: avoid double hash lookups
         match groups.entry(y) {
             Occupied(entry) => entry.into_mut().push(*x),
-            Vacant(entry) => { entry.insert(vec![*x]); () },
+            Vacant(entry) => {
+                entry.insert(vec![*x]);
+                ()
+            }
         }
     }
 
-    groups.into_iter().map(|(_, v)| v).collect::<Vec<Vec<Point>>>()
+    groups
+        .into_iter()
+        .map(|(_, v)| v)
+        .collect::<Vec<Vec<Point>>>()
 }
 
 pub fn run(points: &[Point], n: u32, iters: u32) -> Vec<Vec<Point>> {
     let mut centroids: Vec<Point> = points.iter().take(n as usize).cloned().collect();
 
-    for _ in (0 .. iters) {
-        centroids = clusters(points, &centroids).iter().map(|g| avg(&g)).collect();
+    for _ in 0..iters {
+        centroids = clusters(points, &centroids)
+            .iter()
+            .map(|g| avg(&g))
+            .collect();
     }
     clusters(points, &centroids)
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,2 +1,5 @@
+#[macro_use]
+extern crate serde_derive;
+
 pub mod point;
 pub mod algo;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,11 +1,12 @@
 extern crate time;
 extern crate kmeans;
-extern crate rustc_serialize;
+
+extern crate serde;
+extern crate serde_json;
 
 use std::path::Path;
 use std::fs::File;
 use std::io::Read;
-use rustc_serialize::json;
 
 use time::now;
 use kmeans::point::Point;
@@ -14,7 +15,7 @@ use kmeans::algo::run;
 fn benchmark(points: &[Point], times: i32) -> f64 {
     let start = now().to_timespec();
 
-    for _ in (0 .. times) {
+    for _ in 0..times {
         run(points, 10, 15);
     }
 
@@ -25,11 +26,11 @@ fn benchmark(points: &[Point], times: i32) -> f64 {
 
 fn main() {
     let mut file = File::open(&Path::new("../points.json")).unwrap();
-    let mut buffer: Vec<u8> = vec!();
+    let mut buffer: Vec<u8> = vec![];
     let _ = file.read_to_end(&mut buffer).unwrap();
     let filestr = String::from_utf8(buffer).unwrap();
 
-    let points: Vec<Point> = json::decode(&filestr).unwrap();
+    let points: Vec<Point> = serde_json::from_str(&filestr).unwrap();
     let iterations = 100;
 
     println!("The average time is {}", benchmark(&points, iterations));

--- a/rust/src/point.rs
+++ b/rust/src/point.rs
@@ -1,13 +1,16 @@
-extern crate rustc_serialize;
+extern crate serde;
+extern crate serde_json;
 
 use std::hash::{Hash, Hasher};
 use std::mem;
-use std::ops::{Add,Sub};
+use std::ops::{Add, Sub};
 
-#[derive(Debug, PartialEq, PartialOrd, Copy, Clone)]
+#[derive(Deserialize, Debug, PartialEq, PartialOrd, Copy, Clone)]
 pub struct Point(pub f64, pub f64);
 
-fn sq(x: f64) -> f64 { x * x }
+fn sq(x: f64) -> f64 {
+    x * x
+}
 
 impl Point {
     pub fn norm(self: &Point) -> f64 {
@@ -45,14 +48,14 @@ impl Sub for Point {
 
 impl Eq for Point {}
 
-impl rustc_serialize::Decodable for Point {
-    fn decode<D: rustc_serialize::Decoder>(d: &mut D) -> Result<Point, D::Error> {
-        d.read_tuple(2, |d| {
-            d.read_tuple_arg(0, |d| d.read_f64()).and_then(|e1| {
-                d.read_tuple_arg(1, |d| d.read_f64()).map(|e2| {
-                    Point(e1, e2)
-                })
-            })
-        })
-    }
-}
+// impl rustc_serialize::Decodable for Point {
+//     fn decode<D: rustc_serialize::Decoder>(d: &mut D) -> Result<Point, D::Error> {
+//         d.read_tuple(2, |d| {
+//             d.read_tuple_arg(0, |d| d.read_f64()).and_then(|e1| {
+//                 d.read_tuple_arg(1, |d| d.read_f64()).map(|e2| {
+//                     Point(e1, e2)
+//                 })
+//             })
+//         })
+//     }
+// }


### PR DESCRIPTION
`rust` deprecated `rustc_serialize`.
Now `serde` is the default crate for serialization/deserialization.